### PR TITLE
Developの取り込み（channelにprivateMakeコマンド、roleDelコマンドを追加、その他改修あり）

### DIFF
--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -167,13 +167,23 @@ class AdminCog(commands.Cog, name='管理用'):
             await ctx.channel.send('チャンネル名を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
+        # メッセージの所属するカテゴリを取得
+        guild = ctx.channel.guild
+        category_id = ctx.message.channel.category_id
+        category = guild.get_channel(category_id)
+
+        # カテゴリーが存在するなら、カテゴリーについて確認メッセージに記載する
+        category_text = ''
+        if category is not None:
+            category_text = f'カテゴリー「**{category.name}**」に、\n';
+
         # 念の為、確認する
-        confirm_text = f'チャンネル **{channelName}** を作成してよろしいですか？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        confirm_text = f'{category_text}パブリックなチャンネル **{channelName}** を作成してよろしいですか？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
         await ctx.channel.purge(limit=1)
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
-                return user == self.command_author and str(reaction.emoji) == '👌'
+            return user == self.command_author and str(reaction.emoji) == '👌'
 
         # リアクション待ち
         try:
@@ -181,20 +191,108 @@ class AdminCog(commands.Cog, name='管理用'):
         except asyncio.TimeoutError:
             await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
         else:
-            # メッセージの所属するカテゴリにテキストチャンネルを作成する
-            guild = ctx.channel.guild
-            category_id = ctx.message.channel.category_id
-            category = guild.get_channel(category_id)
             try:
                 # カテゴリが存在しない場合と存在する場合で処理を分ける
                 if category is None:
                     new_channel = await guild.create_text_channel(name=channelName)
                 else:
+                    # メッセージの所属するカテゴリにテキストチャンネルを作成する
                     new_channel = await category.create_text_channel(name=channelName)
             except discord.errors.Forbidden:
                 await ctx.channel.send('→権限がないため、実行できませんでした！')
             else:
                 await ctx.channel.send(f'<#{new_channel.id}>を作成しました！')
+
+    # channelコマンドのサブコマンドprivateMake
+    # チャンネルを作成する
+    @channel.command(aliases=['pmk', 'pcraft', 'primk'], description='プライベートチャンネルを作成します')
+    async def privateMake(self, ctx, channelName=None):
+        """
+        引数に渡したチャンネル名でプライベートなテキストチャンネルを作成します（コマンドを打ったチャンネルの所属するカテゴリに作成されます）。
+        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        """
+        self.command_author = ctx.author
+
+        # チャンネル名がない場合は実施不可
+        if channelName is None:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('チャンネル名を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
+            return
+
+        # トップロールが@everyoneの場合は実施不可
+        if ctx.author.top_role.position == 0:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('everyone権限しか保持していない場合、このコマンドは使用できません。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
+            return
+
+        # メッセージの所属するカテゴリを取得
+        guild = ctx.channel.guild
+        category_id = ctx.message.channel.category_id
+        category = guild.get_channel(category_id)
+
+        # カテゴリーが存在するなら、カテゴリーについて確認メッセージに記載する
+        category_text = ''
+        if category is not None:
+            category_text = f'カテゴリー「**{category.name}**」に、\n';
+
+        # Guildのロールを取得し、@everyone以外のロールで最も下位なロール以上は書き込めるような辞書型overwritesを作成
+        permissions = []
+        for guild_role in ctx.guild.roles:
+            # authorのeveryoneの1つ上のロールよりも下位のポジションの場合
+            if guild_role.position < ctx.author.roles[1].position:
+                permissions.append(
+                    discord.PermissionOverwrite(
+                        read_messages=False
+                        ,read_message_history=False
+                    )
+                )
+            else:
+                permissions.append(
+                    discord.PermissionOverwrite(
+                        read_messages=True
+                        ,read_message_history=True
+                    )
+                )
+        overwrites = dict(zip(ctx.guild.roles, permissions))
+
+        if settings.IS_DEBUG:
+            print('-----author\'s role-----------------------------------------------------------')
+            for author_role in ctx.author.roles:
+                print(f'id:{author_role.id}, name:{author_role.name}, position:{author_role.position}')
+            print('-----------------------------------------------------------------')
+            print('-----Guild\'s role-----------------------------------------------------------')
+            for guild_role in ctx.guild.roles:
+                print(f'id:{guild_role.id}, name:{guild_role.name}, position:{guild_role.position}')
+            print('-----------------------------------------------------------------')
+
+        # 念の為、確認する
+        confirm_text = f'{category_text}プライベートなチャンネル **{channelName}** を作成してよろしいですか()？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.channel.purge(limit=1)
+        await ctx.channel.send(confirm_text)
+
+        def check(reaction, user):
+            return user == self.command_author and str(reaction.emoji) == '👌'
+
+        # リアクション待ち
+        try:
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+        except asyncio.TimeoutError:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('＊リアクションがなかったのでキャンセルしました！(プライベートなチャンネルを立てようとしていました。)')
+        else:
+            try:
+                # カテゴリが存在しない場合と存在する場合で処理を分ける
+                if category is None:
+                    new_channel = await guild.create_text_channel(name=channelName, overwrites=overwrites)
+                else:
+                    # メッセージの所属するカテゴリにテキストチャンネルを作成する
+                    new_channel = await category.create_text_channel(name=channelName, overwrites=overwrites)
+            except discord.errors.Forbidden:
+                await ctx.channel.purge(limit=1)
+                await ctx.channel.send('＊権限がないため、実行できませんでした！(プライベートなチャンネルを立てようとしていました。)')
+            else:
+                await ctx.channel.purge(limit=1)
+                await ctx.channel.send(f'`/channel privateMake`コマンドでプライベートなチャンネルを作成しました！')
 
     # channelコマンドのサブコマンドtopic
     # チャンネルのトピックを設定する

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -199,7 +199,7 @@ class AdminCog(commands.Cog, name='管理用'):
     # channelコマンドのサブコマンドtopic
     # チャンネルのトピックを設定する
     @channel.command(aliases=['t', 'tp'], description='チャンネルにトピックを設定します')
-    async def topic(self, ctx, topicWord=None):
+    async def topic(self, ctx, *, topicWord=None):
         """
         引数に渡した文字列でテキストチャンネルのトピックを設定します。
         10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -319,7 +319,7 @@ class AdminCog(commands.Cog, name='管理用'):
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
-                return user == self.command_author and str(reaction.emoji) == '👌'
+            return user == self.command_author and str(reaction.emoji) == '👌'
 
         # リアクション待ち
         try:
@@ -327,7 +327,7 @@ class AdminCog(commands.Cog, name='管理用'):
         except asyncio.TimeoutError:
             await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
         else:
-            # チャンネルにトピックを設定する　
+            # チャンネルにトピックを設定する
             try:
                 await ctx.channel.edit(topic=topicWord)
             except discord.errors.Forbidden:

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -327,8 +327,8 @@ class AdminCog(commands.Cog, name='管理用'):
 
     # channelコマンドのサブコマンドroleDel
     # チャンネルのロールを削除する（テキストチャンネルが見えないようにする）
-    @channel.command(aliases=['rd', 'delrole', 'dr'], description='チャンネルのロールを削除します')
-    async def roleDel(self, ctx, targetRole=None):
+    @channel.command(aliases=['rd', 'roledel', 'deleterole' 'delrole', 'dr'], description='チャンネルのロールを削除します')
+    async def roleDelete(self, ctx, targetRole=None):
         """
         指定したロールがテキストチャンネルを見れないように設定します（自分とおなじ権限まで指定可能（ただしチャンネルに閲覧できるロールがない場合、表示されなくなります！））。
         10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
@@ -382,7 +382,7 @@ class AdminCog(commands.Cog, name='管理用'):
             print(bot_overwrites_pair)
             # 権限が初期設定なら
             if (bot_overwrites_pair[0].value == 0) and (bot_overwrites_pair[1].value == 0):
-                bot_overwrite = discord.PermissionOverwrite(read_messages=True)
+                bot_overwrite = discord.PermissionOverwrite(read_messages=True,read_message_history=True)
                 botRoleUpdateFlag = True
             if targetRole == bot_role.name:
                 attention_text = f'＊＊これを実行するとBOTが書き込めなくなるため、**権限削除に成功した場合でもチャンネルに結果が表示されません**。\n'

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -240,19 +240,9 @@ class AdminCog(commands.Cog, name='管理用'):
         for guild_role in ctx.guild.roles:
             # authorのeveryoneの1つ上のロールよりも下位のポジションの場合
             if guild_role.position < ctx.author.roles[1].position:
-                permissions.append(
-                    discord.PermissionOverwrite(
-                        read_messages=False
-                        ,read_message_history=False
-                    )
-                )
+                permissions.append(discord.PermissionOverwrite(read_messages=False))
             else:
-                permissions.append(
-                    discord.PermissionOverwrite(
-                        read_messages=True
-                        ,read_message_history=True
-                    )
-                )
+                permissions.append(discord.PermissionOverwrite(read_messages=True))
         overwrites = dict(zip(ctx.guild.roles, permissions))
 
         if settings.IS_DEBUG:

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -335,6 +335,92 @@ class AdminCog(commands.Cog, name='管理用'):
             else:
                 await ctx.channel.send(f'チャンネル「{ctx.channel.name}」のトピックに**「{topicWord}」**を設定しました！')
 
+    # channelコマンドのサブコマンドroleDel
+    # チャンネルのロールを削除する（テキストチャンネルが見えないようにする）
+    @channel.command(aliases=['rd', 'delrole', 'dr'], description='チャンネルのロールを削除します')
+    async def roleDel(self, ctx, targetRole=None):
+        """
+        指定したロールがテキストチャンネルを見れないように設定します（自分とおなじ権限まで指定可能（ただしチャンネルに閲覧できるロールがない場合、表示されなくなります！））。
+        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        """
+        self.command_author = ctx.author
+        # 対象のロールがない場合は実施不可
+        if targetRole is None:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('チャンネルから削除するロールを指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
+            return
+        # トップロールが@everyoneの場合は実施不可
+        if ctx.author.top_role.position == 0:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('everyone権限しか保持していない場合、このコマンドは使用できません。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
+            return
+
+        underRoles = [guild_role.name for guild_role in ctx.guild.roles if guild_role.position <= ctx.author.top_role.position]
+        underRolesWithComma = ",".join(underRoles).replace('@', '')
+
+        role = discord.utils.get(ctx.guild.roles, name=targetRole)
+        # 指定したロール名がeveryoneの場合、@everyoneとして処理する
+        if targetRole == 'everyone':
+            role = ctx.guild.default_role
+
+        # 削除対象としたロールが、実行者のトップロールより大きい場合は実施不可(ロールが存在しない場合も実施不可)
+        if role is None:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('存在しないロールのため、実行できませんでした(大文字小文字を正確に入力ください)。\n＊削除するロールとして{0}が指定できます。\nあなたのコマンド：`{1}`'.format(underRolesWithComma,ctx.message.clean_content))
+            return
+        elif role > ctx.author.top_role:
+            await ctx.channel.purge(limit=1)
+            await ctx.channel.send('削除対象のロールの方が権限が高いため、実行できませんでした。\n＊削除するロールとして{0}が指定できます。\nあなたのコマンド：`{1}`'.format(underRolesWithComma,ctx.message.clean_content))
+            return
+
+        # 読み書き権限を削除したoverwritesを作る
+        overwrite =    discord.PermissionOverwrite(read_messages=False)
+
+        # botのロール確認
+        botRoleUpdateFlag = False
+        botUser = self.bot.user
+        botMember = discord.utils.find(lambda m: m.name == botUser.name, ctx.channel.guild.members)
+
+        bot_role,bot_overwrite = None, None
+        attention_text = ''
+        if botMember.top_role.position == 0:
+            if targetRole == 'everyone':
+                attention_text = f'＊＊これを実行するとBOTが書き込めなくなるため、**権限削除に成功した場合でもチャンネルに結果が表示されません**。\n'
+        else:
+            bot_role = botMember.top_role
+            bot_overwrites_pair = ctx.channel.overwrites_for(bot_role).pair()
+            print(bot_overwrites_pair)
+            # 権限が初期設定なら
+            if (bot_overwrites_pair[0].value == 0) and (bot_overwrites_pair[1].value == 0):
+                bot_overwrite = discord.PermissionOverwrite(read_messages=True)
+                botRoleUpdateFlag = True
+            if targetRole == bot_role.name:
+                attention_text = f'＊＊これを実行するとBOTが書き込めなくなるため、**権限削除に成功した場合でもチャンネルに結果が表示されません**。\n'
+
+        # 念の為、確認する
+        confirm_text = f'{attention_text}このチャンネルから、ロール**「{targetRole}」** を削除しますか？\n（{targetRole}はチャンネルを見ることができなくなります。）\n 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.channel.purge(limit=1)
+        await ctx.channel.send(confirm_text)
+
+        def check(reaction, user):
+            return user == self.command_author and str(reaction.emoji) == '👌'
+
+        # リアクション待ち
+        try:
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+        except asyncio.TimeoutError:
+            await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
+        else:
+            # チャンネルに権限を上書きする
+            try:
+                if botRoleUpdateFlag:
+                    await ctx.channel.set_permissions(bot_role, overwrite=bot_overwrite)
+                await ctx.channel.set_permissions(role, overwrite=overwrite)
+            except discord.errors.Forbidden:
+                await ctx.channel.send('→権限がないため、実行できませんでした！')
+            else:
+                await ctx.channel.send(f'チャンネル「{ctx.channel.name}」からロール**「{targetRole}」**の閲覧権限を削除しました！')
+
     # チャンネル作成時に実行されるイベントハンドラを定義
     @commands.Cog.listener()
     async def on_guild_channel_create(self, channel: discord.abc.GuildChannel):

--- a/cogs/modules/grouping.py
+++ b/cogs/modules/grouping.py
@@ -48,8 +48,7 @@ class MakeTeam:
 
     # メンバー取得
     async def get_members(self, ctx):
-        if self.set_mem(ctx) is False:
-            return self.vc_state_err
+        self.set_mem(ctx)
         return self.vc_list
 
     # チーム数を指定した場合のチーム分け


### PR DESCRIPTION
9848811 メンバー取得はボイスチャンネルに人が接続していなくても実行できるように修正
8da5187 channelのtopicコマンド時、keyword-only-argumentsを使うようにした（二重引用符が不要でスペースや改行できる）
ccfa68b channelにprivateMakeコマンドを追加（プライベートなテキストチャンネルを作成するもの）。それに付随し、makeコマンドの見直し。
9d427e2 細かな記載ミスの修正
49f1bd5 channelにroleDelコマンドを追加（チャンネルを閲覧できるロールを削除するもの）
decdf2a privateMakeで権限削除する対象からread_message_historyを消した
ac63844 roleDelの名前を修正(roleDeleteへ)し、エイリアス追加。権限が初期値のときの権限追加にread_message_historyを増やした