### PR TITLE
Bug fix heroku rc

### DIFF
--- a/assitantbot.py
+++ b/assitantbot.py
@@ -33,7 +33,6 @@ class AssistantBot(commands.Bot):
     # Botの準備完了時に呼び出されるイベント
     async def on_ready(self):
         print('We have logged in as {0}'.format(self.user))
-        print(bot.guilds)
 
 # クラス定義。HelpCommandクラスを継承。
 class Help(commands.HelpCommand):

--- a/cogs/modules/reactionchannel.py
+++ b/cogs/modules/reactionchannel.py
@@ -45,6 +45,10 @@ class ReactionChannel:
                     get_control_channel = discord.utils.get(guild.text_channels, name=self.REACTION_CHANNEL)
                     if get_control_channel is not None:
                         last_message = await get_control_channel.history(limit=1).flatten()
+                        if settings.IS_DEBUG:
+                            print(f'＋＋＋＋{last_message}＋＋＋＋')
+                            print(f'len: {len(last_message)}, con: {last_message[0].content}, attchSize:{len(last_message[0].attachments)}')
+                            print(f'date: {Attachment_file_date} <<<<<<< {last_message[0].created_at}, {Attachment_file_date < last_message[0].created_at}')
                         # last_messageがない場合以外で、reaction-channel.jsonが本文である場合、ファイルを取得する
                         if len(last_message) != 0 and last_message[0].content == self.FILE:
                             if len(last_message[0].attachments) > 0:
@@ -62,6 +66,8 @@ class ReactionChannel:
             if settings.IS_DEBUG:
                 if not os.path.exists(file_path_first_time):
                     print(f'{file_path_first_time}は作成できませんでした')
+                else:
+                    print(f'{file_path_first_time}は作成できています')
                 print('get_discord_attachment_file is over!')
 
     async def set_discord_attachment_file(self, guild:discord.Guild):

--- a/cogs/modules/reactionchannel.py
+++ b/cogs/modules/reactionchannel.py
@@ -49,7 +49,8 @@ class ReactionChannel:
                             print(f'＋＋＋＋{last_message}＋＋＋＋')
                             if len(last_message) != 0: 
                                 print(f'len: {len(last_message)}, con: {last_message[0].content}, attchSize:{len(last_message[0].attachments)}')
-                                print(f'date: {Attachment_file_date} <<<<<<< {last_message[0].created_at}, {Attachment_file_date < last_message[0].created_at}')
+                                if Attachment_file_date is not None:
+                                    print(f'date: {Attachment_file_date} <<<<<<< {last_message[0].created_at}, {Attachment_file_date < last_message[0].created_at}')
                         # last_messageがない場合以外で、reaction-channel.jsonが本文である場合、ファイルを取得する
                         if len(last_message) != 0 and last_message[0].content == self.FILE:
                             if len(last_message[0].attachments) > 0:

--- a/cogs/modules/reactionchannel.py
+++ b/cogs/modules/reactionchannel.py
@@ -23,7 +23,7 @@ class ReactionChannel:
         self.rc_err = ''
 
     # Heroku対応
-    async def get_discord_attachment_file(self, guild:discord.Guild):
+    async def get_discord_attachment_file(self):
         # Herokuの時のみ実施
         if settings.IS_HEROKU:
             if settings.IS_DEBUG:
@@ -47,8 +47,9 @@ class ReactionChannel:
                         last_message = await get_control_channel.history(limit=1).flatten()
                         if settings.IS_DEBUG:
                             print(f'＋＋＋＋{last_message}＋＋＋＋')
-                            print(f'len: {len(last_message)}, con: {last_message[0].content}, attchSize:{len(last_message[0].attachments)}')
-                            print(f'date: {Attachment_file_date} <<<<<<< {last_message[0].created_at}, {Attachment_file_date < last_message[0].created_at}')
+                            if len(last_message) != 0: 
+                                print(f'len: {len(last_message)}, con: {last_message[0].content}, attchSize:{len(last_message[0].attachments)}')
+                                print(f'date: {Attachment_file_date} <<<<<<< {last_message[0].created_at}, {Attachment_file_date < last_message[0].created_at}')
                         # last_messageがない場合以外で、reaction-channel.jsonが本文である場合、ファイルを取得する
                         if len(last_message) != 0 and last_message[0].content == self.FILE:
                             if len(last_message[0].attachments) > 0:
@@ -127,7 +128,7 @@ class ReactionChannel:
         # 読み込み
         try:
             # Herokuの時のみ、チャンネルからファイルを取得する
-            await self.get_discord_attachment_file(guild)
+            await self.get_discord_attachment_file()
 
             print(f'＊＊読み込み＊＊')
             file_path = join(dirname(__file__), 'files' + os.sep + self.FILE)

--- a/cogs/reactionchannelercog.py
+++ b/cogs/reactionchannelercog.py
@@ -15,12 +15,12 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
     # ReactionChannelerCogクラスのコンストラクタ。Botを受取り、インスタンス変数として保持。
     def __init__(self, bot):
         self.bot = bot
-        self.reaction_channel = ReactionChannel(self.bot.guilds, self.bot)
+        self.reaction_channel = None
 
     # cogが準備できたら読み込みする
     @commands.Cog.listener()
     async def on_ready(self):
-        print("load cog")
+        print(f"load reaction-channeler's guilds{self.bot.guilds}")
         self.reaction_channel = ReactionChannel(self.bot.guilds, self.bot)
 
     # リアクションチャンネラーコマンド群


### PR DESCRIPTION
読み込みが想定通りではなかったのでログを埋め込み試行錯誤。
結局、チャンネルに読み込み履歴の権限が無く、読み込めていなかったのが原因だったように見える。
＊別のBOT（BOT_A）がチャンネルを作成していたため正常に動作し、BOT_Bについては権限を手動で付与したため履歴の閲覧権限が漏れていた
ログを多少見やすい形に直した認識なのでその点を取り込み。