### PR TITLE
環境変数がない場合、異常終了してしまうバグを修正

### DIFF
--- a/cogs/modules/settings.py
+++ b/cogs/modules/settings.py
@@ -4,12 +4,16 @@ from dotenv import load_dotenv
 from logging import DEBUG, INFO, WARN, ERROR
 
 def if_env(str):
-    if str.upper() == 'TRUE':
+    if str is None:
+        return False
+    elif str.upper() == 'TRUE':
         return True
     else:
         return False
 
 def get_log_level(str):
+    if str is None:
+        return WARN
     upper_str = str.upper()
     if upper_str == 'DEBUG':
         return DEBUG


### PR DESCRIPTION
環境変数の設定がない場合、strがNONEのため以下のエラーが発生（Herokuで発生して気づいた）
```
mac-mini:discord-bot-heroku mac_mini$ python3 assitantbot.py
Traceback (most recent call last):
  File "assitantbot.py", line 2, in <module>
    from cogs.modules import settings
  File "/Users/mac_mini/discord-bot-heroku/cogs/modules/settings.py", line 1, in <module>
    from _typeshed import NoneType
ModuleNotFoundError: No module named '_typeshed'
```