### PR TITLE
リアクション待ち時間の改善、ログレベル見直し、ラジコ検索機能の追加

### DIFF
--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -16,6 +16,8 @@ class AdminCog(commands.Cog, name='管理用'):
     """
     管理用の機能です。
     """
+    TIMEOUT_TIME = 30.0
+
     # AdminCogクラスのコンストラクタ。Botを受取り、インスタンス変数として保持。
     def __init__(self, bot):
         self.bot = bot
@@ -123,20 +125,20 @@ class AdminCog(commands.Cog, name='管理用'):
 
         # 指定がない、または、不正な場合は、コマンドを削除。そうではない場合、コマンドを削除し、指定の数だけ削除する
         if limit_num is None:
-            await ctx.channel.purge(limit=1, check=is_me)
+            await ctx.message.delete()
             await ctx.channel.send('オプションとして、1以上の数値を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
         if limit_num.isdecimal():
             limit_num = int(limit_num) + 1
         else:
-            await ctx.channel.purge(limit=1, check=is_me)
+            await ctx.message.delete()
             await ctx.channel.send('有効な数字ではないようです。オプションは1以上の数値を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
         if limit_num > 1000:
             limit_num = 1000
         elif limit_num < 2:
-            await ctx.channel.purge(limit=1, check=is_me)
+            await ctx.message.delete()
             await ctx.channel.send('オプションは1以上の数値を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
@@ -170,12 +172,12 @@ class AdminCog(commands.Cog, name='管理用'):
     async def make(self, ctx, channelName=None):
         """
         引数に渡したチャンネル名でテキストチャンネルを作成します（コマンドを打ったチャンネルの所属するカテゴリに作成されます）。
-        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        30秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
         """
         self.command_author = ctx.author
         # チャンネル名がない場合は実施不可
         if channelName is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('チャンネル名を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
@@ -190,8 +192,8 @@ class AdminCog(commands.Cog, name='管理用'):
             category_text = f'カテゴリー「**{category.name}**」に、\n';
 
         # 念の為、確認する
-        confirm_text = f'{category_text}パブリックなチャンネル **{channelName}** を作成してよろしいですか？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
-        await ctx.channel.purge(limit=1)
+        confirm_text = f'{category_text}パブリックなチャンネル **{channelName}** を作成してよろしいですか？ 問題ない場合、30秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.message.delete()
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
@@ -199,9 +201,9 @@ class AdminCog(commands.Cog, name='管理用'):
 
         # リアクション待ち
         try:
-            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=self.TIMEOUT_TIME, check=check)
         except asyncio.TimeoutError:
-            await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
+            await ctx.channel.send('→リアクションがなかったのでチャンネル作成をキャンセルしました！')
         else:
             try:
                 # カテゴリが存在しない場合と存在する場合で処理を分ける
@@ -211,7 +213,7 @@ class AdminCog(commands.Cog, name='管理用'):
                     # メッセージの所属するカテゴリにテキストチャンネルを作成する
                     new_channel = await category.create_text_channel(name=channelName)
             except discord.errors.Forbidden:
-                await ctx.channel.send('→権限がないため、実行できませんでした！')
+                await ctx.channel.send('→権限がないため、チャンネル作成できませんでした！')
             else:
                 await ctx.channel.send(f'<#{new_channel.id}>を作成しました！')
 
@@ -221,19 +223,19 @@ class AdminCog(commands.Cog, name='管理用'):
     async def privateMake(self, ctx, channelName=None):
         """
         引数に渡したチャンネル名でプライベートなテキストチャンネルを作成します（コマンドを打ったチャンネルの所属するカテゴリに作成されます）。
-        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        30秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
         """
         self.command_author = ctx.author
 
         # チャンネル名がない場合は実施不可
         if channelName is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('チャンネル名を指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
         # トップロールが@everyoneの場合は実施不可
         if ctx.author.top_role.position == 0:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('everyone権限しか保持していない場合、このコマンドは使用できません。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
@@ -267,18 +269,18 @@ class AdminCog(commands.Cog, name='管理用'):
         logger.debug('-----------------------------------------------------------------')
 
         # 念の為、確認する
-        confirm_text = f'{category_text}プライベートなチャンネル **{channelName}** を作成してよろしいですか()？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
-        await ctx.channel.purge(limit=1)
-        await ctx.channel.send(confirm_text)
+        confirm_text = f'{category_text}プライベートなチャンネル **{channelName}** を作成してよろしいですか()？ 問題ない場合、30秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.message.delete()
+        confirm_message = await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
             return user == self.command_author and str(reaction.emoji) == '👌'
 
         # リアクション待ち
         try:
-            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=self.TIMEOUT_TIME, check=check)
         except asyncio.TimeoutError:
-            await ctx.channel.purge(limit=1)
+            await confirm_message.delete()
             await ctx.channel.send('＊リアクションがなかったのでキャンセルしました！(プライベートなチャンネルを立てようとしていました。)')
         else:
             try:
@@ -289,10 +291,10 @@ class AdminCog(commands.Cog, name='管理用'):
                     # メッセージの所属するカテゴリにテキストチャンネルを作成する
                     new_channel = await category.create_text_channel(name=channelName, overwrites=overwrites)
             except discord.errors.Forbidden:
-                await ctx.channel.purge(limit=1)
+                await confirm_message.delete()
                 await ctx.channel.send('＊権限がないため、実行できませんでした！(プライベートなチャンネルを立てようとしていました。)')
             else:
-                await ctx.channel.purge(limit=1)
+                await confirm_message.delete()
                 await ctx.channel.send(f'`/channel privateMake`コマンドでプライベートなチャンネルを作成しました！')
 
     # channelコマンドのサブコマンドtopic
@@ -301,12 +303,12 @@ class AdminCog(commands.Cog, name='管理用'):
     async def topic(self, ctx, *, topicWord=None):
         """
         引数に渡した文字列でテキストチャンネルのトピックを設定します。
-        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        30秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
         """
         self.command_author = ctx.author
         # トピックがない場合は実施不可
         if topicWord is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('トピックを指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
@@ -314,8 +316,8 @@ class AdminCog(commands.Cog, name='管理用'):
         original_topic = ''
         if ctx.channel.topic is not None:
             original_topic = f'このチャンネルには、トピックとして既に**「{ctx.channel.topic}」**が設定されています。\nそれでも、'
-        confirm_text = f'{original_topic}このチャンネルのトピックに**「{topicWord}」** を設定しますか？ 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
-        await ctx.channel.purge(limit=1)
+        confirm_text = f'{original_topic}このチャンネルのトピックに**「{topicWord}」** を設定しますか？ 問題ない場合、30秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.message.delete()
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
@@ -323,15 +325,15 @@ class AdminCog(commands.Cog, name='管理用'):
 
         # リアクション待ち
         try:
-            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=self.TIMEOUT_TIME, check=check)
         except asyncio.TimeoutError:
-            await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
+            await ctx.channel.send('→リアクションがなかったので、トピックの設定をキャンセルしました！')
         else:
             # チャンネルにトピックを設定する
             try:
                 await ctx.channel.edit(topic=topicWord)
             except discord.errors.Forbidden:
-                await ctx.channel.send('→権限がないため、実行できませんでした！')
+                await ctx.channel.send('→権限がないため、トピックを設定できませんでした！')
             else:
                 await ctx.channel.send(f'チャンネル「{ctx.channel.name}」のトピックに**「{topicWord}」**を設定しました！')
 
@@ -341,17 +343,17 @@ class AdminCog(commands.Cog, name='管理用'):
     async def roleDelete(self, ctx, targetRole=None):
         """
         指定したロールがテキストチャンネルを見れないように設定します（自分とおなじ権限まで指定可能（ただしチャンネルに閲覧できるロールがない場合、表示されなくなります！））。
-        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        30秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
         """
         self.command_author = ctx.author
         # 対象のロールがない場合は実施不可
         if targetRole is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('チャンネルから削除するロールを指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
         # トップロールが@everyoneの場合は実施不可
         if ctx.author.top_role.position == 0:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('everyone権限しか保持していない場合、このコマンドは使用できません。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
 
@@ -365,11 +367,11 @@ class AdminCog(commands.Cog, name='管理用'):
 
         # 削除対象としたロールが、実行者のトップロールより大きい場合は実施不可(ロールが存在しない場合も実施不可)
         if role is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('存在しないロールのため、実行できませんでした(大文字小文字を正確に入力ください)。\n＊削除するロールとして{0}が指定できます。\nあなたのコマンド：`{1}`'.format(underRolesWithComma,ctx.message.clean_content))
             return
         elif role > ctx.author.top_role:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('削除対象のロールの方が権限が高いため、実行できませんでした。\n＊削除するロールとして{0}が指定できます。\nあなたのコマンド：`{1}`'.format(underRolesWithComma,ctx.message.clean_content))
             return
 
@@ -398,8 +400,8 @@ class AdminCog(commands.Cog, name='管理用'):
                 attention_text = f'＊＊これを実行するとBOTが書き込めなくなるため、**権限削除に成功した場合でもチャンネルに結果が表示されません**。\n'
 
         # 念の為、確認する
-        confirm_text = f'{attention_text}このチャンネルから、ロール**「{targetRole}」** を削除しますか？\n（{targetRole}はチャンネルを見ることができなくなります。）\n 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
-        await ctx.channel.purge(limit=1)
+        confirm_text = f'{attention_text}このチャンネルから、ロール**「{targetRole}」** を削除しますか？\n（{targetRole}はチャンネルを見ることができなくなります。）\n 問題ない場合、30秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.message.delete()
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
@@ -407,9 +409,9 @@ class AdminCog(commands.Cog, name='管理用'):
 
         # リアクション待ち
         try:
-            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=self.TIMEOUT_TIME, check=check)
         except asyncio.TimeoutError:
-            await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
+            await ctx.channel.send('→リアクションがなかったのでチャンネルのロール削除をキャンセルしました！')
         else:
             # チャンネルに権限を上書きする
             try:
@@ -417,7 +419,7 @@ class AdminCog(commands.Cog, name='管理用'):
                     await ctx.channel.set_permissions(bot_role, overwrite=bot_overwrite)
                 await ctx.channel.set_permissions(role, overwrite=overwrite)
             except discord.errors.Forbidden:
-                await ctx.channel.send('→権限がないため、実行できませんでした！')
+                await ctx.channel.send('→権限がないため、チャンネルのロールを削除できませんでした！')
             else:
                 await ctx.channel.send(f'チャンネル「{ctx.channel.name}」からロール**「{targetRole}」**の閲覧権限を削除しました！')
 

--- a/cogs/admincog.py
+++ b/cogs/admincog.py
@@ -451,7 +451,7 @@ class AdminCog(commands.Cog, name='管理用'):
             category = guild.get_channel(channel.category_id)
             if category is not None:
                 str += '\nCategory: {0}'.format(category.name)
-        logger.debug(f'***{str}***')
+        logger.info(f'***{str}***')
         await self.sendGuildChannel(guild, str, channel.created_at)
 
     # メンバーGuild参加時に実行されるイベントハンドラを定義
@@ -473,7 +473,7 @@ class AdminCog(commands.Cog, name='管理用'):
         guild = member.guild
         str = 'member: {0}が{1}しました'.format(member, event_text)
 
-        logger.debug(f'***{str}***')
+        logger.info(f'***{str}***')
 
         await self.sendGuildChannel(guild, str, dt)
 

--- a/cogs/modules/auditlogchannel.py
+++ b/cogs/modules/auditlogchannel.py
@@ -25,5 +25,7 @@ class AuditLogChannel:
                     logger.debug(self.channel)
                     if self.channel is not None:
                         return True
+
         self.alc_err = '管理用のチャンネルが登録されていません。'
+        logger.error(self.alc_err)
         return False

--- a/cogs/modules/radiko.py
+++ b/cogs/modules/radiko.py
@@ -1,0 +1,123 @@
+from logging import getLogger
+
+import aiohttp
+import datetime, random, hashlib
+import discord
+import re
+import mojimoji
+
+logger = getLogger(__name__)
+
+class Radiko:
+    PREF_CD = {'北海道':'01','青森県':'02','岩手県':'03','宮城県':'04','秋田県':'05','山形県':'06','福島県':'07','茨城県':'08','栃木県':'09','群馬県':'10','埼玉県':'11','千葉県':'12','東京都':'13','神奈川県':'14','新潟県':'15','富山県':'16','石川県':'17','福井県':'18','山梨県':'19','長野県':'20','岐阜県':'21','静岡県':'22','愛知県':'23','三重県':'24','滋賀県':'25','京都府':'26','大阪府':'27','兵庫県':'28','奈良県':'29','和歌山県':'30','鳥取県':'31','島根県':'32','岡山県':'33','広島県':'34','山口県':'35','徳島県':'36','香川県':'37','愛媛県':'38','高知県':'39','福岡県':'40','佐賀県':'41','長崎県':'42','熊本県':'43','大分県':'44','宮崎県':'45','鹿児島県':'46','沖縄県':'47'}
+    RADIKO_URL = 'http://radiko.jp/v3/api/program/search'
+    LIMIT_NUM = 5
+    DEFAULT_AREA = 'JP13'
+
+    def __init__(self):
+        self.content = ''
+        self.r_err = ''
+
+    async def radiko_search(self, keyword='', filter='', areaName=''):
+        # どっちも空文字になるなら、入れ替えて検索する
+        if self.convert_filter(filter) == self.convert_prefCd(areaName) == '':
+            filter,areaName = areaName,filter
+        response = await self.search_radiko_result(keyword, self.convert_filter(filter), self.convert_prefCd(areaName))
+
+        if response is None:
+            return
+
+        result_count = response['meta']['result_count']
+        self.content = f"検索結果は、{result_count}件です"
+        if result_count > self.LIMIT_NUM:
+            self.content += f'(ただし、{self.LIMIT_NUM}件を超えた部分については表示されません)'
+        elif result_count == 0:
+            return
+
+        embed_field = ''
+
+        count = 1
+        for key in response['data']:
+            data = ''
+            data += f"**title:{key['title']}**"
+            if key['start_time'][:10] == key['end_time'][:10]:
+                start2end = key['start_time'][:16] + '-' + key['end_time'][11:16]
+            else:
+                start2end = key['start_time'][:16] + '-' + key['end_time'][:16]
+            data += '\ndatetime:' + start2end
+            data += '\nstation_id:' + key['station_id']
+            data += '\nperformer:' + key['performer'] if key['performer'] != '' else '\nperformer:(なし)'
+
+            info_data = re.sub(r'<br *?/>', '@@', key['info'])
+            info_data = re.sub(r'<[^>]*?>', '', info_data)
+            info_data = re.sub(r'\t|\n|(&[lg]t; *)', '', info_data)
+            info_data = re.sub(r'@+ +?@+', '', info_data)
+            info_data = re.sub(r'@{2,}', ' ', info_data)
+            info_data = info_data.strip()
+            info_data = mojimoji.zen_to_han(info_data, kana=False)
+            if len(embed_field + data + '\ninfo:' + info_data) > 1700:
+                data += '\ninfo:(文字数超えのため削除)'
+                logger.debug('文字数超で削除されたinfo:' + info_data)
+            else:
+                data += f'\ninfo:{info_data}'
+
+            embed_field += f'{str(count)}件目: {data}\n'
+            count = count + 1
+            if count > self.LIMIT_NUM:
+                break
+
+        embed = discord.Embed(title = f'keyword:{keyword}, filter:{filter}, areaName:{areaName} の結果です', description=embed_field,type='rich', inline=False)
+        return embed
+
+    def generate_uid(self):
+        """
+        rdk_uid生成関数
+        """
+        rnd = random.random() * 1000000000
+        ms = datetime.timedelta.total_seconds(datetime.datetime.now() - datetime.datetime(1970, 1, 1)) * 1000
+        return hashlib.md5(str(rnd + ms).encode('utf-8')).hexdigest()
+
+    def convert_prefCd(self, prefName):
+        if ('都' in prefName or '道' in prefName or '府' in prefName or '県' in prefName) and self.PREF_CD[prefName].isdecimal():
+            return 'JP' + self.PREF_CD[prefName]
+        elif 'JP' in prefName:
+            return prefName
+        else:
+            return ''
+
+    def convert_filter(self, filter):
+        if '未来' in filter or 'future' in filter:
+            return 'future' 
+        elif '過去' in filter or 'past' in filter:
+            return 'past'
+        else:
+            return ''
+
+    async def search_radiko_result(self, keyword='', filter='', area_id=DEFAULT_AREA):
+        # ref. https://turtlechan.hatenablog.com/entry/2019/06/25/195451
+        area_id_with_defalut_area = self.DEFAULT_AREA if area_id == '' else area_id
+        params = {
+            'key': keyword,
+            'filter': filter,
+            'start_day': '',
+            'end_day': '',
+            'area_id': area_id_with_defalut_area,
+            'region_id': '',
+            'cul_area_id': area_id_with_defalut_area,
+            'page_idx': '0',
+            'uid': self.generate_uid(),
+            'row_limit': '10',
+            'app_id': 'pc',
+            'action_id': '0',
+            }
+        response = None
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(self.RADIKO_URL, params=params) as r:
+                if r.status == 200:
+                    response = await r.json()
+                    return response
+                else:
+                    self.r_err = 'Radikoの番組表検索に失敗しました。'
+                    logger.warn(self.r_err)
+                    return

--- a/cogs/modules/reactionchannel.py
+++ b/cogs/modules/reactionchannel.py
@@ -60,7 +60,7 @@ class ReactionChannel:
                                     Attachment_file_date = last_message[0].created_at
                                     file_path = join(dirname(__file__), 'files' + os.sep + self.FILE)
                                     await last_message[0].attachments[0].save(file_path)
-                                    logger.debug(f'channel_file_save:{guild.name}')
+                                    logger.info(f'channel_file_save:{guild.name}')
                     else:
                         logger.warn(f'{guild}: に所定のチャンネルがありません')
             else:
@@ -91,7 +91,7 @@ class ReactionChannel:
                 overwrites = dict(zip(target, permissions))
 
                 try:
-                    logger.debug(f'＊＊＊{self.REACTION_CHANNEL}を作成しました！＊＊＊')
+                    logger.info(f'＊＊＊{self.REACTION_CHANNEL}を作成しました！＊＊＊')
                     get_control_channel = await guild.create_text_channel(name=self.REACTION_CHANNEL, overwrites=overwrites)
                 except discord.errors.Forbidden:
                     logger.error(f'＊＊＊{self.REACTION_CHANNEL}の作成に失敗しました！＊＊＊')
@@ -105,7 +105,7 @@ class ReactionChannel:
             # チャンネルにファイルを添付する
             file_path = join(dirname(__file__), 'files' + os.sep + self.FILE)
             await get_control_channel.send(self.FILE, file=discord.File(file_path))
-            logger.debug(f'＊＊＊{get_control_channel.name}へファイルを添付しました！＊＊＊')
+            logger.info(f'＊＊＊{get_control_channel.name}へファイルを添付しました！＊＊＊')
 
             logger.debug('set_discord_attachment_file is over!')
 
@@ -167,6 +167,7 @@ class ReactionChannel:
         except pickle.PickleError:
             # 書き込みに失敗したらなにもしない
             self.rc_err = '保管に失敗しました。'
+            logger.error(self.rc_err)
 
     # 追加するリアクションチャネルが問題ないかチェック
     def check(self, ctx, reaction:str, channel:str):
@@ -241,7 +242,9 @@ class ReactionChannel:
         if await self.save(guild) is False:
             return self.rc_err
 
-        return f'リアクションチャンネルの登録に成功しました！\n{reaction} → <#{get_channel.id}>'
+        msg = f'リアクションチャンネルの登録に成功しました！\n{reaction} → <#{get_channel.id}>'
+        logger.info(msg)
+        return msg
 
     async def list(self, ctx):
         guild = ctx.guild

--- a/cogs/modules/scrapboxsidandpnames.py
+++ b/cogs/modules/scrapboxsidandpnames.py
@@ -52,7 +52,8 @@ class ScrapboxSidAndPnames:
             if len(self.targets) > 0:
                 return True
 
-        self.sbsu_err = '展開対象のSCRAPBOXのSID、プロジェクトが登録されていません。'
+        self.sbsu_err = '展開対象のScrapboxのSID、プロジェクトが登録されていません。'
+        logger.error(self.sbsu_err)
         return False
 
     def check(self, message:discord.Message):
@@ -76,24 +77,25 @@ class ScrapboxSidAndPnames:
 
         json = None
         target_url = ''
-        if mo is not None:
-            if mo.group(1): 
-                target_url = 'https://scrapbox.io/api/pages/'+ self.target_project + '/' + mo.group(1)
+        if mo is not None and mo.group(1):
+            target_url = 'https://scrapbox.io/api/pages/'+ self.target_project + '/' + mo.group(1)
 
-                async with aiohttp.ClientSession(cookies=cookies) as session:
-                    async with session.get(target_url) as r:
-                        if r.status == 200:
-                            json = await r.json()
+            async with aiohttp.ClientSession(cookies=cookies) as session:
+                async with session.get(target_url) as r:
+                    if r.status == 200:
+                        json = await r.json()
 
-                if json is not None:
-                    embed = discord.Embed(title = json['title'], description = " ".join(json['descriptions']), url=mo.group(0), type='rich')
-                    embed.set_author(name=json['user']['displayName'], icon_url=json['user']['photo'])
+            if json is not None:
+                embed = discord.Embed(title = json['title'], description = " ".join(json['descriptions']), url=mo.group(0), type='rich')
+                embed.set_author(name=json['user']['displayName'], icon_url=json['user']['photo'])
 
-                    if json['image']:
-                        embed.set_thumbnail(url=json['image'])
+                if json['image']:
+                    embed.set_thumbnail(url=json['image'])
 
-                    updated = datetime.datetime.fromtimestamp(json['updated'])
-                    embed.add_field(name='Updated', value=updated.strftime('%Y/%m/%d(%a) %H:%M:%S'))
+                updated = datetime.datetime.fromtimestamp(json['updated'])
+                embed.add_field(name='Updated', value=updated.strftime('%Y/%m/%d(%a) %H:%M:%S'))
 
-                    return embed
-
+                return embed
+        else:
+            logger.debug('展開対象外のため、対応しない')
+            return

--- a/cogs/onmessagecog.py
+++ b/cogs/onmessagecog.py
@@ -91,9 +91,8 @@ class OnMessageCog(commands.Cog, name="メッセージイベント用"):
         if message.author == botUser:# 自分は無視する
             return
 
-        if self.scrapboxSidAndPnames.SCRAPBOX_URL_PATTERN in message.clean_content:
-            if self.scrapboxSidAndPnames.setup(message.guild):
-                await self.scrapbox_url_expand(message)
+        if self.scrapboxSidAndPnames.SCRAPBOX_URL_PATTERN in message.clean_content and self.scrapboxSidAndPnames.setup(message.guild):
+            await self.scrapbox_url_expand(message)
         else:
             return
 
@@ -101,7 +100,8 @@ class OnMessageCog(commands.Cog, name="メッセージイベント用"):
     async def scrapbox_url_expand(self, targetMessage: discord.Message):
         if (self.scrapboxSidAndPnames.check(targetMessage)):
             embed = await self.scrapboxSidAndPnames.expand(targetMessage)
-            await targetMessage.channel.send(embed=embed)
+            if embed is not None:
+                await targetMessage.channel.send(embed=embed)
         else:
             return
 

--- a/cogs/reactionchannelercog.py
+++ b/cogs/reactionchannelercog.py
@@ -16,6 +16,7 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
     リアクションチャンネラー機能のカテゴリ(リアクションをもとに実行するアクション含む)。
     """
     SPLIT_SIZE = 1900
+    TIMEOUT_TIME = 30.0
 
     # ReactionChannelerCogクラスのコンストラクタ。Botを受取り、インスタンス変数として保持。
     def __init__(self, bot):
@@ -53,7 +54,7 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
         """
         # リアクション、チャンネルがない場合は実施不可
         if reaction is None or channel is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('リアクションとチャンネルを指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
         msg = await self.reaction_channel.add(ctx, reaction, channel)
@@ -74,13 +75,13 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
     async def purge(self, ctx):
         """
         リアクションチャンネラー（＊）で反応する絵文字を全て削除します。
-        10秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
+        30秒以内に👌(ok_hand)のリアクションをつけないと実行されませんので、素早く対応ください。
         ＊指定した絵文字でリアクションされた時、チャンネルに通知する機能のこと
         """
         command_author = ctx.author
         # 念の為、確認する
-        confirm_text = f'全てのリアクションチャンネラーを削除しますか？\n 問題ない場合、10秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
-        await ctx.channel.purge(limit=1)
+        confirm_text = f'全てのリアクションチャンネラーを削除しますか？\n 問題ない場合、30秒以内に👌(ok_hand)のリアクションをつけてください。\nあなたのコマンド：`{ctx.message.clean_content}`'
+        await ctx.message.delete()
         await ctx.channel.send(confirm_text)
 
         def check(reaction, user):
@@ -88,9 +89,9 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
 
         # リアクション待ち
         try:
-            reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=self.TIMEOUT_TIME, check=check)
         except asyncio.TimeoutError:
-            await ctx.channel.send('→リアクションがなかったのでキャンセルしました！')
+            await ctx.channel.send('→リアクションがなかったので、リアクションチャンネラーの全削除をキャンセルしました！')
         else:
             msg = await self.reaction_channel.purge(ctx)
             await ctx.channel.send(msg)
@@ -105,7 +106,7 @@ class ReactionChannelerCog(commands.Cog, name="リアクションチャンネラ
         """
         # リアクション、チャンネルがない場合は実施不可
         if reaction is None or channel is None:
-            await ctx.channel.purge(limit=1)
+            await ctx.message.delete()
             await ctx.channel.send('リアクションとチャンネルを指定してください。\nあなたのコマンド：`{0}`'.format(ctx.message.clean_content))
             return
         msg = await self.reaction_channel.delete(ctx, reaction, channel)

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,9 @@ Discord用のBot。discord.pyのBot Commands Frameworkを使用して実装。�
 `/vcmembers` ボイスチャンネルに接続しているメンバーリストを取得  
 ![image(vcmembers)](https://github.com/tetsuya-ki/images/blob/main/discord-bot-heroku/vcmembers.png?raw=true)
 
+`/radikoSearch` ラジコの番組表を検索する機能  
+![image(radikoSearch)](https://github.com/tetsuya-ki/images/blob/main/discord-bot-heroku/radiko_search.png?raw=true)
+
 ### 管理用カテゴリ(admincog.pyで実装)
 
 `/channel` チャンネルを操作するコマンド（サブコマンド必須）。チャンネルの操作権限を渡すと、削除も可能だから嫌だなと思って作ったコマンド。  

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ websockets==6.0
 wrapt==1.12.1
 yarl==1.5.1
 zope.interface==5.1.0
+mojimoji==0.0.11


### PR DESCRIPTION
1. リアクション待ち時間を30秒にした。その際削除するメッセージを指定するよう改善。その他メッセージ内容改善 df4a2fc
2. ログレベルの見直しとログの追加 299a1ed
3. 無駄にifの階層が深買った点を修正。ScrapboxのURLがページ未指定の場合展開しないよう修正 b49fcc5
4. requirements.txt更新(mojimoji追加)、ラジコ検索機能の追加 6c62f01
5. readme.mdにラジコ検索機能の説明を追加 fba1e12