### PR TITLE
ボイスチャンネルを使用するものについて、Botはメンバーとして認めないように修正

### DIFF
--- a/cogs/modules/grouping.py
+++ b/cogs/modules/grouping.py
@@ -40,6 +40,9 @@ class MakeTeam:
                     continue
             self.vc_list += '🔈' + v_channel.name + '\n'
             for vc_member in v_channel.members:
+                # botはメンバーとして計上しない
+                if vc_member.bot:
+                    continue
                 self.vc_members.append(vc_member) # VCメンバリスト取得
                 self.vc_list += '> ' + vc_member.name + '\n'
 


### PR DESCRIPTION
## 起因
NGワードゲームでBotにDMを試み、エラーが発生し処理が終了されたため、バグに気づいた

## 対処
ボイスチャンネルでメンバーを計上する際、Botかどうかチェックするように変更